### PR TITLE
pass correct param value for asciidoc conversion

### DIFF
--- a/shimgo.go
+++ b/shimgo.go
@@ -28,7 +28,7 @@ func ConvertFromAsciiDoc(content []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return server.doConversion(RST, content)
+	return server.doConversion(ASCIIDOC, content)
 }
 
 func SupportsAsciiDoc() bool {


### PR DESCRIPTION
Looked into sources and noticed this. I guess it's a copy-paste issue. Let's fix this! 😊