### PR TITLE
fix server not being terminated

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -104,7 +104,7 @@ func TestStartIfNeeded(t *testing.T) {
 		assert(t, s.pid == 0, "pid isnt set because server is running")
 		assert(t, !s.hasError(), "no errrors")
 
-		cleanup(t, s)
+		s.setup()
 	}
 }
 

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -36,6 +36,7 @@ func cleanup(t *testing.T, s *shimServer) {
 			require(t, err == nil, "kill service proc", err)
 		}
 	}
+	s.stop()
 	s.Lock()
 	defer s.Unlock()
 	s.setup()


### PR DESCRIPTION
There are issues with server termination I caught using context.
The goroutine didn't received ctx.Done() and was hanging forever.
The simpler and working solution I found is to use channel
and close it when termination is needed.
This works perfectly with Hugo.